### PR TITLE
Implement backup logging

### DIFF
--- a/components/file_storage_mgr/CMakeLists.txt
+++ b/components/file_storage_mgr/CMakeLists.txt
@@ -2,6 +2,7 @@ SET(SOURCES
     src/pv_sdc.c
     src/pv_fs.c
     src/sdc_tests.c
+    src/pv_backup_log.c
 )
 
 SET(INCLUDE_DIRS

--- a/components/file_storage_mgr/include/pv_fs.h
+++ b/components/file_storage_mgr/include/pv_fs.h
@@ -16,3 +16,4 @@
 /* FUNCTION DEFS */
 esp_err_t pv_init_fs(void);
 esp_err_t pv_fmt_sdc(void);
+esp_err_t pv_delete_dir(const char *path);

--- a/components/file_storage_mgr/include/pv_sdc.h
+++ b/components/file_storage_mgr/include/pv_sdc.h
@@ -17,4 +17,4 @@ esp_err_t pv_init_sdc(void);
 void pv_test_sdc(void);
 void pv_card_get(sdmmc_card_t **out_card);
 esp_err_t pv_update_backup_log(const char *serial_number, const char *file_path); // TODO: Move this to a more appropriate file during integration
-bool is_backedUp(const char *serial_number, const char *file_path); // TODO: Move this to a more appropriate file during integration
+bool pv_is_backedUp(const char *serial_number, const char *file_path); // TODO: Move this to a more appropriate file during integration

--- a/components/file_storage_mgr/include/pv_sdc.h
+++ b/components/file_storage_mgr/include/pv_sdc.h
@@ -3,8 +3,18 @@
 #include "esp_err.h"
 #include "sdmmc_cmd.h"
 
+#include "pv_fs.h"
+
+// TODO: Move this to a more appropriate file during integration
+/* Update Log Defines*/
+#define DEVICE_DIRECTORY_NAME_MAX_LENGTH 64
+#define BACKUP_PATH_MAX_LENGTH 128
+#define LOG_ENTRY_MAX_LENGTH 256
+#define LOG_FILE_NAME "log.csv"
 
 /* FUNCTION DEFS */
 esp_err_t pv_init_sdc(void);
 void pv_test_sdc(void);
 void pv_card_get(sdmmc_card_t **out_card);
+esp_err_t pv_update_backup_log(const char *serial_number, const char *file_path); // TODO: Move this to a more appropriate file during integration
+bool is_backedUp(const char *serial_number, const char *file_path); // TODO: Move this to a more appropriate file during integration

--- a/components/file_storage_mgr/include/sdc_tests.h
+++ b/components/file_storage_mgr/include/sdc_tests.h
@@ -5,3 +5,5 @@
 
 /* FUNCTION DEFS */
 void test_sdcWriteFile(void);
+void test_log_writes(void);
+void test_log_checks(void);

--- a/components/file_storage_mgr/src/pv_backup_log.c
+++ b/components/file_storage_mgr/src/pv_backup_log.c
@@ -1,0 +1,121 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdbool.h>
+
+#include "pv_sdc.h"
+#include "pv_fs.h"
+#include "esp_log.h"
+#include "pv_logging.h"
+
+#define TAG "PV_UPDATE_LOG"
+
+/***************************************************************************
+ * Function:    pv_update_backup_log
+ * Purpose:     Updates the backup log with the given filepath that was backed up.
+ *              It creates a directory for the serial number if it does not exist.
+ * Parameters:  serial_number - The serial number to identify the device.
+ *              file_path - The path of file (on the mobile device) that was backed up
+ * Returns:     ESP_OK on success
+ *              ESP_FAIL else
+ * Note:        The log file will caontain entries in the format:
+ *              "file_path",<valid_bit> // valid is 1 if the file is not deleted, 0 if it is deleted
+ *              The log file will be created in the directory: SD_CARD_BASE_PATH/serial_number
+ ***************************************************************************/
+esp_err_t pv_update_backup_log(const char *serial_number, const char *file_path) {
+    char dir_path[DEVICE_DIRECTORY_NAME_MAX_LENGTH] = {0};
+    char log_entry[LOG_ENTRY_MAX_LENGTH] = {0};
+    struct stat st = {0};
+    FILE *log_file;
+    int log_file_path_name_length = DEVICE_DIRECTORY_NAME_MAX_LENGTH + 1 + sizeof(LOG_FILE_NAME); // +1 for slash, sizeof includes null terminator
+    char log_file_path[log_file_path_name_length];
+
+    snprintf(dir_path, sizeof(dir_path), "%s/%s", SD_CARD_BASE_PATH, serial_number);
+
+    // Check if directory exists
+    if (stat(dir_path, &st) != 0) {
+        // Directory does not exist, create it
+        if (mkdir(dir_path, S_IRWXU | S_IRWXG | S_IRWXO) != 0) {
+            PV_LOGE(TAG, "Failed to create directory");
+            return ESP_FAIL;
+        }
+    }
+
+    // Construct full log file path
+    snprintf(log_file_path, log_file_path_name_length, "%s/%s", dir_path, LOG_FILE_NAME);
+
+    log_file = fopen(log_file_path, "a");
+    if (!log_file) {
+        PV_LOGE(TAG, "Failed to open or create log file");
+        return ESP_FAIL;
+    }
+
+
+    // Write entry to log: "file_path",<valid_bit>
+    if (snprintf(log_entry, LOG_ENTRY_MAX_LENGTH, "\"%s\",1\n", file_path) >= LOG_ENTRY_MAX_LENGTH) {
+        PV_LOGE(TAG, "Log entry exceeds maximum length defined by LOG_ENTRY_MAX_LENGTH");
+        fclose(log_file);
+        return ESP_FAIL;
+    }
+    fprintf(log_file, log_entry);
+    fclose(log_file);
+    
+    return ESP_OK;
+}
+
+/***************************************************************************
+ * Function:    is_backedUp
+ * Purpose:     Check if a file is backed up by checking the log file for device 
+ *              device with the given serial number. * 
+ * Parameters:  serial_number - The serial number to identify the device.
+ *              file_path - The path of file (on the mobile device) to check
+ * Returns:     true if file is backed up and valid (not deleted)
+ *              false else
+ ***************************************************************************/
+bool is_backedUp(const char *serial_number, const char *file_path) {
+    char dir_path[DEVICE_DIRECTORY_NAME_MAX_LENGTH] = {0};
+    char log_entry[LOG_ENTRY_MAX_LENGTH] = {0};
+    char logged_path[BACKUP_PATH_MAX_LENGTH] = {0};
+    int valid_bit = 0;
+    struct stat st = {0};
+    FILE *log_file;
+    int log_file_path_name_length = DEVICE_DIRECTORY_NAME_MAX_LENGTH + 1 + sizeof(LOG_FILE_NAME); // +1 for slash, sizeof includes null terminator
+    char log_file_path[log_file_path_name_length];
+
+    snprintf(dir_path, sizeof(dir_path), "%s/%s", SD_CARD_BASE_PATH, serial_number);
+
+    // Check if directory exists
+    if (stat(dir_path, &st) != 0) {
+        // Directory does not exist, therefore file is not backed up
+        return false;
+    }
+
+    // Construct full log file path
+    snprintf(log_file_path, log_file_path_name_length, "%s/%s", dir_path, LOG_FILE_NAME);
+
+    log_file = fopen(log_file_path, "r");
+    if (!log_file) {
+        PV_LOGE(TAG, "Failed to open log file");
+        return false; // Log file does not exist, therefore file is not backed up
+    }
+
+    // Read the log file line by line to find the file_path
+    while (fgets(log_entry, LOG_ENTRY_MAX_LENGTH, log_file) != NULL) {
+        // Check if the line contains the file_path and is valid
+        if (sscanf(log_entry, "\"%[^\"]\",%d", logged_path, &valid_bit) == 2){
+            if (strcmp(logged_path, file_path) == 0 && valid_bit == 1) {
+                fclose(log_file);
+                return true; // File is backed up
+            }
+        }
+    }
+
+
+    fclose(log_file);
+    return false; // File not found in log or is marked as deleted
+}

--- a/components/file_storage_mgr/src/pv_backup_log.c
+++ b/components/file_storage_mgr/src/pv_backup_log.c
@@ -69,7 +69,7 @@ esp_err_t pv_update_backup_log(const char *serial_number, const char *file_path)
 }
 
 /***************************************************************************
- * Function:    is_backedUp
+ * Function:    pv_is_backedUp
  * Purpose:     Check if a file is backed up by checking the log file for device 
  *              device with the given serial number. * 
  * Parameters:  serial_number - The serial number to identify the device.
@@ -77,7 +77,7 @@ esp_err_t pv_update_backup_log(const char *serial_number, const char *file_path)
  * Returns:     true if file is backed up and valid (not deleted)
  *              false else
  ***************************************************************************/
-bool is_backedUp(const char *serial_number, const char *file_path) {
+bool pv_is_backedUp(const char *serial_number, const char *file_path) {
     char dir_path[DEVICE_DIRECTORY_NAME_MAX_LENGTH] = {0};
     char log_entry[LOG_ENTRY_MAX_LENGTH] = {0};
     char logged_path[BACKUP_PATH_MAX_LENGTH] = {0};

--- a/components/file_storage_mgr/src/pv_sdc.c
+++ b/components/file_storage_mgr/src/pv_sdc.c
@@ -94,5 +94,7 @@ esp_err_t pv_init_sdc(void){
 void pv_test_sdc(void){
     UNITY_BEGIN();
     RUN_TEST(test_sdcWriteFile);
+    RUN_TEST(test_log_writes);
+    RUN_TEST(test_log_checks);
     UNITY_END();  
 }

--- a/components/file_storage_mgr/src/sdc_tests.c
+++ b/components/file_storage_mgr/src/sdc_tests.c
@@ -128,13 +128,13 @@ void test_log_checks(void) {
     fclose(log_file);
 
     // Check if the valid file paths are recognized as backed up
-    TEST_ASSERT_TRUE(is_backedUp(serial_number, file_path1_v));
-    TEST_ASSERT_TRUE(is_backedUp(serial_number, file_path2_v));
+    TEST_ASSERT_TRUE(pv_is_backedUp(serial_number, file_path1_v));
+    TEST_ASSERT_TRUE(pv_is_backedUp(serial_number, file_path2_v));
 
     // Check if the invalid file path is recognized as not backed up
-    TEST_ASSERT_FALSE(is_backedUp(serial_number, file_path1_i));
+    TEST_ASSERT_FALSE(pv_is_backedUp(serial_number, file_path1_i));
 
     // Check if a missing file path is recognized as not backed up
-    TEST_ASSERT_FALSE(is_backedUp(serial_number, file_path3_m));
+    TEST_ASSERT_FALSE(pv_is_backedUp(serial_number, file_path3_m));
 
 }

--- a/components/file_storage_mgr/src/sdc_tests.c
+++ b/components/file_storage_mgr/src/sdc_tests.c
@@ -5,6 +5,7 @@
 #include "unity.h"
 #include "sdc_tests.h"
 #include "pv_sdc.h"
+#include "pv_fs.h"
 
 
 /***************************************************************************
@@ -46,4 +47,94 @@ void test_sdcWriteFile(void){
 
     // Check if the read content matches the written content
     TEST_ASSERT_EQUAL_STRING(test_data, readBuff);
+}
+
+
+/***************************************************************************
+ * Function:    test_log_writes
+ * Purpose:     Tests the log writing functionality by writing a log entry
+ *              and checking if it is correctly written to the log file.
+ * Parameters:  None
+ * Returns:     None
+ ***************************************************************************/
+void test_log_writes(void) {
+    char *serial_number = "12345678";
+    char *file_path = "/path/to/test_file.txt";
+    char readline[300];
+    int log_file_path_name_length = DEVICE_DIRECTORY_NAME_MAX_LENGTH + 1 + sizeof(LOG_FILE_NAME); // +1 for slash, sizeof includes null terminator
+    char log_file_path[log_file_path_name_length];
+    char log_dir[DEVICE_DIRECTORY_NAME_MAX_LENGTH];
+    char log_entry[LOG_ENTRY_MAX_LENGTH] = {0};
+
+    // Clear the log file directory if it exists
+    snprintf(log_dir, sizeof(log_dir), "%s/%s", SD_CARD_BASE_PATH, serial_number);
+    pv_delete_dir(log_dir);
+
+    // Call the function to update the backup log
+    TEST_ASSERT_EQUAL(ESP_OK, pv_update_backup_log(serial_number, file_path));
+
+    // Check if the log file was created and contains the expected data
+    snprintf(log_file_path, sizeof(log_file_path), "%s/%s/%s", SD_CARD_BASE_PATH, serial_number, LOG_FILE_NAME);
+    FILE *log_file = fopen(log_file_path, "r");
+    TEST_ASSERT_NOT_NULL(log_file); // Check if log file opened successfully
+
+    // Construct the expected log entry
+    snprintf(log_entry, LOG_ENTRY_MAX_LENGTH, "\"%s\",1\n", file_path);
+
+    // Read the first line of the log file
+    fgets(readline, sizeof(readline), log_file);
+    fclose(log_file);
+
+    // Check if the log file contains the expected file path
+    TEST_ASSERT_EQUAL_STRING(log_entry, readline);
+}
+
+/***************************************************************************
+ * Function:    test_log_checks
+ * Purpose:     Tests the log checking functionality by writing a log entry,
+ *              and then checking if the entry is correctly identified as backed up.
+ *              Check false path also.
+ * Parameters:  None
+ * Returns:     None
+ ***************************************************************************/
+void test_log_checks(void) {
+    int log_file_path_name_length = DEVICE_DIRECTORY_NAME_MAX_LENGTH + 1 + sizeof(LOG_FILE_NAME); // +1 for slash, sizeof includes null terminator
+    char log_file_path[log_file_path_name_length];
+    char log_dir[DEVICE_DIRECTORY_NAME_MAX_LENGTH];
+    char *serial_number = "12345678";
+    char *file_path1_v = "/path/to/test_file1_v.txt"; // valid file path
+    char *file_path1_i = "/path/to/test_file1_i.txt"; // invalid file path (deleted)
+    char *file_path2_v = "/path/to/test_file2_v.txt"; // another valid file path
+    char *file_path3_m = "/path/to/test_file3_m.txt"; // missing file path
+
+    
+    // Clear the log file directory if it exists
+    
+    snprintf(log_dir, sizeof(log_dir), "%s/%s", SD_CARD_BASE_PATH, serial_number);
+    pv_delete_dir(log_dir);
+
+    // Construct full log file path
+    snprintf(log_dir, sizeof(log_dir), "%s/%s", SD_CARD_BASE_PATH, serial_number);
+    snprintf(log_file_path, log_file_path_name_length, "%s/%s", log_dir, LOG_FILE_NAME);
+
+    // Update the backup log with valid file paths
+    TEST_ASSERT_EQUAL(ESP_OK, pv_update_backup_log(serial_number, file_path1_v));
+    TEST_ASSERT_EQUAL(ESP_OK, pv_update_backup_log(serial_number, file_path2_v));
+
+    // Append an invalid file path to the log
+    FILE *log_file = fopen(log_file_path, "a");
+    TEST_ASSERT_NOT_NULL(log_file); // Check if log file opened successfully
+    fprintf(log_file, "\"%s\",0\n", file_path1_i); // Mark
+    fclose(log_file);
+
+    // Check if the valid file paths are recognized as backed up
+    TEST_ASSERT_TRUE(is_backedUp(serial_number, file_path1_v));
+    TEST_ASSERT_TRUE(is_backedUp(serial_number, file_path2_v));
+
+    // Check if the invalid file path is recognized as not backed up
+    TEST_ASSERT_FALSE(is_backedUp(serial_number, file_path1_i));
+
+    // Check if a missing file path is recognized as not backed up
+    TEST_ASSERT_FALSE(is_backedUp(serial_number, file_path3_m));
+
 }

--- a/main/main.c
+++ b/main/main.c
@@ -20,7 +20,7 @@ void app_main(void)
     ret = pv_init_sdc();
     if (ret != ESP_OK) {
         PV_LOGE(TAG, "Failed to initialize SD Card.");
-        // return;
+        return;
     }
 
     ret = pv_init_fs();
@@ -30,7 +30,8 @@ void app_main(void)
     }
     
     /* Run peripheral tests */
-    // pv_test_sdc();
+    // Run SD card tests
+    pv_test_sdc();
 
     // Run transfer control tests
     start_transfer_control_tests();


### PR DESCRIPTION
**Changes**
- Implemented pv_update_backup_log and pv_is_backedUp (callable by includeng pv_sdc.h until integration is complete)
- Implemented delete dir helper function

**Testing**
- Added new Unity tests
```
Name: MSSD0
Type: SDHC
Speed: 4.00 MHz (limit: 4.00 MHz)
Size: 29850MB
CSD: ver=2, sector_size=512, capacity=61132800 read_bl_len=9
SSR: bus_width=1
I (414) PV_FS: (pv_init_fs:100) FATFS mounted successfully at /sdcard
./components/file_storage_mgr/src/pv_sdc.c:96:test_sdcWriteFile:PASS
./components/file_storage_mgr/src/pv_sdc.c:97:test_log_writes:PASS
./components/file_storage_mgr/src/pv_sdc.c:98:test_log_checks:PASS

-----------------------
3 Tests 0 Failures 0 Ignored
OK
```